### PR TITLE
fix isActive

### DIFF
--- a/src/main/java/vsu/cs/is/infsysserver/employee/EmployeeService.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/EmployeeService.java
@@ -3,6 +3,7 @@ package vsu.cs.is.infsysserver.employee;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -39,8 +40,8 @@ public class EmployeeService {
     private final ApplicationProperties properties;
     private final PasswordEncoder passwordEncoder;
 
-    public List<EmployeeResponse> getAllEmployees(boolean isActive) {
-        return employeeRepository.findByIsDisabled(!isActive).stream()
+    public List<EmployeeResponse> getAllEmployees() {
+        return employeeRepository.findAll(Sort.by(Sort.Order.asc("isDisabled"), Sort.Order.asc("id"))).stream()
                 .map(employeeMapper::map)
                 .toList();
     }

--- a/src/main/java/vsu/cs/is/infsysserver/employee/adapter/EmployeeMapper.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/adapter/EmployeeMapper.java
@@ -15,6 +15,7 @@ public interface EmployeeMapper {
     @Mapping(source = "user.email", target = "email")
     @Mapping(source = "user.role", target = "mainRole")
     @Mapping(source = "user.twoFactorEnabled", target = "twoFactorEnabled")
+    @Mapping(target = "isActive", expression = "java(!employee.isDisabled())")
     EmployeeResponse map(Employee employee);
 
     @Mapping(source = "user.firstName", target = "firstName")
@@ -22,6 +23,7 @@ public interface EmployeeMapper {
     @Mapping(source = "user.email", target = "email")
     @Mapping(source = "user.login", target = "login")
     @Mapping(source = "user.role", target = "mainRole")
+    @Mapping(target = "isActive", expression = "java(!employee.isDisabled())")
     EmployeeAdminResponse mapAdmin(Employee employee);
 
     Employee map(EmployeeCreateRequest employeeCreateRequest);

--- a/src/main/java/vsu/cs/is/infsysserver/employee/adapter/jpa/EmployeeRepository.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/adapter/jpa/EmployeeRepository.java
@@ -3,12 +3,9 @@ package vsu.cs.is.infsysserver.employee.adapter.jpa;
 import org.springframework.data.jpa.repository.JpaRepository;
 import vsu.cs.is.infsysserver.employee.adapter.jpa.entity.Employee;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 
     Optional<Employee> findByUserLogin(String login);
-
-    List<Employee> findByIsDisabled(boolean isDisabled);
 }

--- a/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/EmployeeController.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/EmployeeController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import vsu.cs.is.infsysserver.employee.EmployeeService;
 import vsu.cs.is.infsysserver.employee.adapter.rest.api.EmployeeApi;
@@ -31,9 +30,8 @@ public class EmployeeController implements EmployeeApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<List<EmployeeResponse>> getAllEmployees(
-            @RequestParam(name = "isActive", defaultValue = "true") boolean isActive) {
-        return ok(employeeService.getAllEmployees(isActive));
+    public ResponseEntity<List<EmployeeResponse>> getAllEmployees() {
+        return ok(employeeService.getAllEmployees());
     }
 
     @Override

--- a/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/api/EmployeeApi.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/api/EmployeeApi.java
@@ -32,10 +32,8 @@ public interface EmployeeApi {
                     )
             }
     )
-    @Operation(summary = "Возваращает всех сотрудников")
-    ResponseEntity<List<EmployeeResponse>> getAllEmployees(
-            @Parameter(description = "Фильтр по активности: true — только активные (по умолчанию), "
-                    + "false — только отключённые") boolean isActive);
+    @Operation(summary = "Возваращает всех сотрудников (неактивные в конце списка)")
+    ResponseEntity<List<EmployeeResponse>> getAllEmployees();
 
     @ApiResponses(value = {
             @ApiResponse(

--- a/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/dto/response/EmployeeAdminResponse.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/dto/response/EmployeeAdminResponse.java
@@ -42,6 +42,8 @@ public record EmployeeAdminResponse(
         @Schema(description = "Проводит ли занятия", example = "false")
         Boolean hasLessons,
         @Schema(description = "Роль пользователя", example = "MODERATOR")
-        Role mainRole
+        Role mainRole,
+        @Schema(description = "Активен ли сотрудник", example = "true")
+        Boolean isActive
 ) {
 }

--- a/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/dto/response/EmployeeResponse.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/adapter/rest/dto/response/EmployeeResponse.java
@@ -42,6 +42,8 @@ public record EmployeeResponse(
         @Schema(description = "Роль пользователя", example = "MODERATOR")
         Role mainRole,
         @Schema(description = "Включена ли двухфакторная аутентификация", example = "false")
-        boolean twoFactorEnabled
+        boolean twoFactorEnabled,
+        @Schema(description = "Активен ли сотрудник", example = "true")
+        Boolean isActive
 ) {
 }

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/StudentService.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/StudentService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.apache.poi.ss.usermodel.*;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -31,8 +32,8 @@ public class StudentService {
     private final DepartmentRepository departmentRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public List<StudentResponse> getAllStudents(boolean isActive) {
-        return studentRepository.findByIsDisabled(!isActive).stream()
+    public List<StudentResponse> getAllStudents() {
+        return studentRepository.findAll(Sort.by(Sort.Order.asc("isDisabled"), Sort.Order.asc("id"))).stream()
                 .map(StudentResponse::new)
                 .toList();
     }

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/jpa/StudentRepository.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/jpa/StudentRepository.java
@@ -16,8 +16,6 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
 
     List<Student> findBySupervisorId(Long supervisorId);
 
-    List<Student> findByIsDisabled(boolean isDisabled);
-
     @Transactional
     @Modifying
     @Query("UPDATE Student s SET s.supervisor = null WHERE s.supervisor.id = :supervisorId")

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/StudentController.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/StudentController.java
@@ -35,8 +35,8 @@ public class StudentController {
     private final JwtService jwtService;
 
     @GetMapping("/students")
-    public List<StudentResponse> getAll(@RequestParam(name = "isActive", defaultValue = "true") boolean isActive) {
-        return studentService.getAllStudents(isActive);
+    public List<StudentResponse> getAll() {
+        return studentService.getAllStudents();
     }
 
     @PostMapping("/students")

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/response/StudentResponse.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/response/StudentResponse.java
@@ -44,6 +44,8 @@ public class StudentResponse {
 
     private String departmentInfo;
 
+    private Boolean isActive;
+
     public StudentResponse(Student student) {
         this.id = student.getId();
         this.role = student.getUser().getRole();
@@ -67,5 +69,6 @@ public class StudentResponse {
         this.departmentInfo = Optional.ofNullable(student.getDepartment())
                 .map(Department::getDescription)
                 .orElse(null);
+        this.isActive = !student.isDisabled();
     }
 }


### PR DESCRIPTION
Изменения API для фронта                                                                                                                                                                                                          
                                                                                                                                                                                                                                  
  1. GET /api/employees и GET /api/students                                                                                                                                                                                         
   
  - Убран query-параметр isActive. Если фронт его передаёт — будет проигнорирован (можно убрать).                                                                                                                                   
  - Эндпоинт теперь возвращает всех (и активных, и неактивных) одним списком.
  - Сортировка: сначала активные, затем неактивные (внутри каждой группы — по id возрастанию).
  - Если на UI нужны только активные / только неактивные — фильтровать на клиенте по новому полю isActive.

  2. Новое поле в response DTO

  Добавлено поле isActive: boolean в:
  - EmployeeResponse (GET /api/employees, GET /api/employees/{id}, POST /api/employees)
  - EmployeeAdminResponse (GET /api/employees/admin/{id}, PATCH /api/employees/{id})
  - StudentResponse (GET /api/students, GET /api/student/{id}, GET /api/student/account, PUT /api/students/{id}, ответы аутентификации)

  Семантика: isActive = !isDisabled. Соответствует существующему toggle-эндпоинту PATCH /{id}/disable, который инвертирует состояние.

  Пример ответа

  {
    "id": 1,
    "firstName": "Иван",
    "lastName": "Кудинов",
    ...
    "isActive": true
  }