### PR TITLE
fix/hiding_teachers

### DIFF
--- a/src/main/java/vsu/cs/is/infsysserver/employee/EmployeeService.java
+++ b/src/main/java/vsu/cs/is/infsysserver/employee/EmployeeService.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ import vsu.cs.is.infsysserver.user.adapter.jpa.UserRepository;
 import vsu.cs.is.infsysserver.user.adapter.jpa.entity.User;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 @Service
@@ -142,9 +144,12 @@ public class EmployeeService {
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("Host", "parser_api:8000");
-        headers.add("Content-Type", "application/json");
+        headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<ParserEmployeeRequest> entity = new HttpEntity<>(request, headers);
+        String body = "{\"employee_id\":" + employee.getId() + "}";
+        headers.setContentLength(body.getBytes(StandardCharsets.UTF_8).length);
+
+        HttpEntity<String> entity = new HttpEntity<>(body, headers);
 
         ResponseEntity<Void> response = restTemplate.postForEntity(
                 properties.services().get("parser").baseUrl() + "/employees/"


### PR DESCRIPTION
## Что изменено

- Исправлена ошибка при скрытии преподавателя с `hasLessons=true`.
- При синхронизации с `inf-sys-parser` backend теперь отправляет JSON с `employee_id` как тело запроса с явным `Content-Length`.
- Это устраняет ситуацию, когда parser получал пустое body и отвечал `400`, из-за чего `PATCH /api/employees/{id}/disable` падал с `500`.

## Причина

`RestTemplate` отправлял объект `ParserEmployeeRequest` в parser chunked-запросом. Parser/gunicorn в текущей конфигурации видел пустое тело:

```text
body: b''
employee_id: This field is required.
