### PR TITLE
Feature/student topics

### DIFF
--- a/src/main/java/vsu/cs/is/infsysserver/security/service/AuthenticationService.java
+++ b/src/main/java/vsu/cs/is/infsysserver/security/service/AuthenticationService.java
@@ -38,6 +38,7 @@ import vsu.cs.is.infsysserver.user.adapter.jpa.UserRepository;
 import vsu.cs.is.infsysserver.user.adapter.jpa.entity.User;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import static vsu.cs.is.infsysserver.security.util.Constants.BEARER_PREFIX;
 
@@ -100,7 +101,7 @@ public class AuthenticationService {
         var jwtToken = jwtService.generateToken(userDetails);
         saveUserToken(savedUser, jwtToken);
 
-        StudentResponse studentResponse = new StudentResponse(student);
+        StudentResponse studentResponse = StudentResponse.fromStudentAndTopics(student, Optional.empty());
 
         return StudentAuthenticationResponse.builder()
                 .accessToken(jwtToken)

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/StudentService.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/StudentService.java
@@ -3,12 +3,19 @@ package vsu.cs.is.infsysserver.student.adapter;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 import org.apache.poi.ss.usermodel.*;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriComponentsBuilder;
 import vsu.cs.is.infsysserver.security.entity.temp.Role;
 import vsu.cs.is.infsysserver.student.adapter.jpa.DepartmentRepository;
 import vsu.cs.is.infsysserver.student.adapter.jpa.StudentRepository;
@@ -22,6 +29,11 @@ import vsu.cs.is.infsysserver.user.adapter.jpa.UserRepository;
 import vsu.cs.is.infsysserver.user.adapter.jpa.entity.User;
 
 import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -35,12 +47,18 @@ public class StudentService {
 
     private static final Pattern START_YEAR_PATTERN = Pattern.compile("^(\\d{4})_");
     private static final Pattern COURSE_PATTERN = Pattern.compile("_(\\d+)к_");
+    private static final String GOOGLE_SHEETS_HOST = "docs.google.com";
+    private static final List<Charset> CSV_CHARSETS = List.of(
+            StandardCharsets.UTF_8,
+            Charset.forName("windows-1251")
+    );
 
     private final StudentRepository studentRepository;
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
     private final PasswordEncoder passwordEncoder;
     private final StudentTopicAssignmentRepository studentTopicAssignmentRepository;
+    private final RestTemplate restTemplate;
 
     public List<StudentResponse> getAllStudents() {
         List<Student> students = studentRepository.findAll(
@@ -166,122 +184,394 @@ public class StudentService {
             return result;
         }
 
-        if (file.getOriginalFilename() == null
-                || !file.getOriginalFilename().toLowerCase().endsWith(".xlsx")) {
-            result.addError(1, "file", "Поддерживается только формат .xlsx");
+        String fileName = Optional.ofNullable(file.getOriginalFilename())
+                .map(name -> name.toLowerCase(Locale.ROOT))
+                .orElse("");
+
+        try {
+            List<ParsedStudentRow> rows;
+            if (fileName.endsWith(".xlsx")) {
+                rows = parseXlsx(file);
+            } else if (fileName.endsWith(".csv")) {
+                rows = parseCsv(file.getBytes());
+            } else {
+                result.addError(1, "file", "Поддерживаются только файлы .xlsx и .csv");
+                return result;
+            }
+            return importRows(rows, result);
+        } catch (HeadersValidationException exception) {
+            result.addError(1, "headers", exception.getMessage());
+            return result;
+        } catch (EmptyFileException exception) {
+            result.addError(1, "file", "Файл пустой");
+            return result;
+        } catch (Exception exception) {
+            result.addError(1, "file", "Не удалось прочитать файл: " + exception.getMessage());
             return result;
         }
+    }
 
+    public StudentImportResponse importStudentsFromGoogleSheet(String url) {
+        StudentImportResponse result = new StudentImportResponse();
+        try {
+            URI exportUri = buildGoogleSheetCsvExportUri(url);
+            byte[] content = downloadGoogleSheet(exportUri);
+            return importRows(parseCsv(content), result);
+        } catch (HeadersValidationException exception) {
+            result.addError(1, "headers", exception.getMessage());
+            return result;
+        } catch (EmptyFileException exception) {
+            result.addError(1, "file", "Таблица пустая");
+            return result;
+        } catch (IllegalArgumentException exception) {
+            result.addError(1, "url", exception.getMessage());
+            return result;
+        } catch (Exception exception) {
+            result.addError(1, "file", "Не удалось прочитать таблицу: " + exception.getMessage());
+            return result;
+        }
+    }
+
+    private StudentImportResponse importRows(List<ParsedStudentRow> rows, StudentImportResponse result) {
+        for (ParsedStudentRow row : rows) {
+            try {
+                String firstNameFull = requireValue(row.firstNameFull(), "Имя");
+                String lastName = requireValue(row.lastName(), "Фамилия");
+                String login = requireValue(row.login(), "Логин");
+                String email = requireValue(row.email(), "Адрес электронной почты");
+
+                String group = trimToNull(row.group());
+
+                if (group == null) {
+                    result.incrementSkipped();
+                    continue;
+                }
+
+                String[] nameParts = firstNameFull.split("\\s+", 2);
+                String firstName = nameParts[0];
+                String patronymic = nameParts.length > 1 ? nameParts[1] : null;
+
+                Integer startYear = null;
+                Integer course = null;
+                Matcher startYearMatcher = START_YEAR_PATTERN.matcher(group);
+                if (startYearMatcher.find()) {
+                    try {
+                        startYear = Integer.parseInt(startYearMatcher.group(1));
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+                Matcher courseMatcher = COURSE_PATTERN.matcher(group);
+                if (courseMatcher.find()) {
+                    try {
+                        course = Integer.parseInt(courseMatcher.group(1));
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+
+                User user = userRepository.findByLogin(login).orElse(null);
+                boolean created = false;
+
+                if (user == null) {
+                    user = new User();
+                    user.setLogin(login);
+                    user.setRole(Role.USER);
+                    user.setPassword("");
+                    created = true;
+                }
+
+                user.setFirstName(firstName);
+                user.setLastName(lastName);
+                user.setEmail(email);
+                user = userRepository.save(user);
+
+                Student student = studentRepository.findByUser_Id(user.getId());
+                if (student == null) {
+                    student = new Student();
+                    student.setUser(user);
+                    created = true;
+                }
+
+                student.setPatronymic(patronymic);
+                student.setGroup(group);
+                student.setStartYear(startYear);
+                student.setCourse(course);
+                studentRepository.save(student);
+
+                if (created) {
+                    result.incrementCreated();
+                } else {
+                    result.incrementUpdated();
+                }
+            } catch (Exception exception) {
+                result.addError(row.rowNumber(), "row", exception.getMessage());
+            }
+        }
+        return result;
+    }
+
+    private List<ParsedStudentRow> parseXlsx(MultipartFile file) throws java.io.IOException {
         try (InputStream inputStream = file.getInputStream();
              Workbook workbook = WorkbookFactory.create(inputStream)) {
 
             Sheet sheet = workbook.getSheetAt(0);
-
             if (sheet == null || sheet.getPhysicalNumberOfRows() == 0) {
-                result.addError(1, "file", "Файл пустой");
-                return result;
+                throw new EmptyFileException();
             }
 
             Row headerRow = sheet.getRow(sheet.getFirstRowNum());
             Map<Integer, String> headerMap = buildHeaderMap(headerRow);
+            validateRequiredHeadersOrThrow(headerMap);
 
-            validateRequiredHeaders(headerMap, result);
-
-            if (!result.getErrors().isEmpty()) {
-                return result;
-            }
-
+            List<ParsedStudentRow> rows = new ArrayList<>();
             for (int i = sheet.getFirstRowNum() + 1; i <= sheet.getLastRowNum(); i++) {
                 Row row = sheet.getRow(i);
-
                 if (row == null || isEmptyRow(row)) {
                     continue;
                 }
-
-                try {
-                    Map<String, String> data = readRow(row, headerMap);
-
-                    String firstNameFull = required(data, "firstName", "Имя");
-                    String lastName = required(data, "lastName", "Фамилия");
-                    String login = required(data, "login", "Логин");
-                    String email = required(data, "email", "Адрес электронной почты");
-
-                    String group = trimToNull(data.get("group"));
-
-                    if (group == null) {
-                        result.incrementSkipped();
-                        continue;
-                    }
-
-                    String[] nameParts = firstNameFull.split("\\s+", 2);
-                    String firstName = nameParts[0];
-                    String patronymic = nameParts.length > 1 ? nameParts[1] : null;
-
-                    Integer startYear = null;
-                    Integer course = null;
-                    Matcher startYearMatcher = START_YEAR_PATTERN.matcher(group);
-                    if (startYearMatcher.find()) {
-                        try {
-                            startYear = Integer.parseInt(startYearMatcher.group(1));
-                        } catch (NumberFormatException ignored) {
-                        }
-                    }
-                    Matcher courseMatcher = COURSE_PATTERN.matcher(group);
-                    if (courseMatcher.find()) {
-                        try {
-                            course = Integer.parseInt(courseMatcher.group(1));
-                        } catch (NumberFormatException ignored) {
-                        }
-                    }
-
-                    User user = userRepository.findByLogin(login).orElse(null);
-                    boolean created = false;
-
-                    if (user == null) {
-                        user = new User();
-                        user.setLogin(login);
-                        user.setRole(Role.USER);
-                        user.setPassword("");
-                        created = true;
-                    }
-
-                    user.setFirstName(firstName);
-                    user.setLastName(lastName);
-                    user.setEmail(email);
-
-                    user = userRepository.save(user);
-
-                    Student student = studentRepository.findByUser_Id(user.getId());
-
-                    if (student == null) {
-                        student = new Student();
-                        student.setUser(user);
-                        created = true;
-                    }
-
-                    student.setPatronymic(patronymic);
-                    student.setGroup(group);
-                    student.setStartYear(startYear);
-                    student.setCourse(course);
-                    studentRepository.save(student);
-
-                    if (created) {
-                        result.incrementCreated();
-                    } else {
-                        result.incrementUpdated();
-                    }
-
-                } catch (Exception exception) {
-                    result.addError(i + 1, "row", exception.getMessage());
-                }
+                Map<String, String> data = readRow(row, headerMap);
+                rows.add(new ParsedStudentRow(
+                        i + 1,
+                        data.get("firstName"),
+                        data.get("lastName"),
+                        data.get("login"),
+                        data.get("email"),
+                        data.get("group")
+                ));
             }
+            return rows;
+        }
+    }
 
-        } catch (Exception exception) {
-            result.addError(1, "file", "Не удалось прочитать файл: " + exception.getMessage());
+    private List<ParsedStudentRow> parseCsv(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            throw new EmptyFileException();
         }
 
+        // Пробуем UTF-8, при наличии маркера невалидной кодировки — windows-1251.
+        String utf8Content = new String(bytes, StandardCharsets.UTF_8);
+        Charset chosenCharset = utf8Content.contains("�")
+                ? Charset.forName("windows-1251")
+                : StandardCharsets.UTF_8;
+
+        IllegalStateException lastException = null;
+        for (Charset charset : chosenCharset == StandardCharsets.UTF_8
+                ? List.of(StandardCharsets.UTF_8)
+                : CSV_CHARSETS) {
+            try {
+                return parseCsvWithCharset(bytes, charset);
+            } catch (IllegalStateException exception) {
+                lastException = exception;
+            }
+        }
+        throw lastException != null
+                ? lastException
+                : new IllegalStateException("Не удалось прочитать CSV-файл");
+    }
+
+    private List<ParsedStudentRow> parseCsvWithCharset(byte[] bytes, Charset charset) {
+        String content = new String(bytes, charset);
+        if (!StringUtils.hasText(content)) {
+            throw new EmptyFileException();
+        }
+
+        char delimiter = detectCsvDelimiter(content);
+        CSVFormat csvFormat = CSVFormat.DEFAULT.builder()
+                .setHeader()
+                .setSkipHeaderRecord(true)
+                .setIgnoreEmptyLines(true)
+                .setIgnoreSurroundingSpaces(true)
+                .setTrim(true)
+                .setDelimiter(delimiter)
+                .build();
+
+        try (CSVParser parser = csvFormat.parse(new StringReader(content))) {
+            Map<Integer, String> headerMap = buildHeaderMapFromCsv(parser.getHeaderMap());
+            validateRequiredHeadersOrThrow(headerMap);
+
+            List<ParsedStudentRow> rows = new ArrayList<>();
+            for (CSVRecord record : parser) {
+                Map<String, String> data = readCsvRow(record, headerMap);
+                if (data.values().stream().allMatch(v -> v == null || v.isBlank())) {
+                    continue;
+                }
+                rows.add(new ParsedStudentRow(
+                        (int) record.getRecordNumber() + 1,
+                        data.get("firstName"),
+                        data.get("lastName"),
+                        data.get("login"),
+                        data.get("email"),
+                        data.get("group")
+                ));
+            }
+            return rows;
+        } catch (java.io.IOException exception) {
+            throw new IllegalStateException("Не удалось прочитать CSV-файл", exception);
+        }
+    }
+
+    private Map<Integer, String> buildHeaderMapFromCsv(Map<String, Integer> rawHeaderPositions) {
+        Map<Integer, String> result = new HashMap<>();
+        for (Map.Entry<String, Integer> entry : rawHeaderPositions.entrySet()) {
+            String normalized = normalizeHeader(entry.getKey());
+            String field = HEADER_FIELD_MAP.get(normalized);
+            if (field != null) {
+                result.put(entry.getValue(), field);
+            }
+        }
         return result;
     }
+
+    private static char detectCsvDelimiter(String content) {
+        String firstNonBlankLine = Arrays.stream(content.split("\\R"))
+                .filter(StringUtils::hasText)
+                .findFirst()
+                .orElse("");
+        long semicolonCount = firstNonBlankLine.chars().filter(c -> c == ';').count();
+        long commaCount = firstNonBlankLine.chars().filter(c -> c == ',').count();
+        return semicolonCount > commaCount ? ';' : ',';
+    }
+
+    private Map<String, String> readCsvRow(CSVRecord record, Map<Integer, String> headerMap) {
+        Map<String, String> result = new HashMap<>();
+        for (Map.Entry<Integer, String> entry : headerMap.entrySet()) {
+            int index = entry.getKey();
+            if (index < record.size()) {
+                result.put(entry.getValue(), record.get(index));
+            }
+        }
+        return result;
+    }
+
+    private void validateRequiredHeadersOrThrow(Map<Integer, String> headerMap) {
+        Set<String> fields = new HashSet<>(headerMap.values());
+        Map<String, String> required = Map.of(
+                "firstName", "Имя",
+                "lastName", "Фамилия",
+                "login", "Логин",
+                "email", "Адрес электронной почты"
+        );
+        for (Map.Entry<String, String> entry : required.entrySet()) {
+            if (!fields.contains(entry.getKey())) {
+                throw new HeadersValidationException(
+                        "Отсутствует обязательная колонка: " + entry.getValue()
+                );
+            }
+        }
+    }
+
+    /**
+     * TODO: вынести вместе с downloadGoogleSheet в общий хелпер
+     * (используется и в StudentTopicsService).
+     */
+    private URI buildGoogleSheetCsvExportUri(String url) {
+        if (!StringUtils.hasText(url)) {
+            throw new IllegalArgumentException("Ссылка на Google Sheets не должна быть пустой");
+        }
+
+        URI sourceUri;
+        try {
+            sourceUri = new URI(url.trim());
+        } catch (URISyntaxException exception) {
+            throw new IllegalArgumentException("Некорректная ссылка на Google Sheets", exception);
+        }
+
+        String host = Optional.ofNullable(sourceUri.getHost()).orElse("");
+        if (!GOOGLE_SHEETS_HOST.equalsIgnoreCase(host)) {
+            throw new IllegalArgumentException("Поддерживаются только ссылки на docs.google.com");
+        }
+
+        String spreadsheetId = extractSpreadsheetId(Optional.ofNullable(sourceUri.getPath()).orElse(""));
+        String gid = extractGid(sourceUri);
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromHttpUrl("https://" + GOOGLE_SHEETS_HOST + "/spreadsheets/d/" + spreadsheetId + "/export")
+                .queryParam("format", "csv");
+        if (StringUtils.hasText(gid)) {
+            builder.queryParam("gid", gid);
+        }
+        return builder.build(true).toUri();
+    }
+
+    private byte[] downloadGoogleSheet(URI uri) {
+        try {
+            byte[] body = restTemplate.getForObject(uri, byte[].class);
+            if (body == null || body.length == 0) {
+                throw new IllegalStateException("Не удалось получить данные из Google Sheets");
+            }
+            return body;
+        } catch (RestClientException exception) {
+            throw new IllegalStateException("Не удалось скачать Google Sheets по ссылке", exception);
+        }
+    }
+
+    private static String extractSpreadsheetId(String path) {
+        String[] parts = path.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("d".equals(parts[i]) && StringUtils.hasText(parts[i + 1])) {
+                return parts[i + 1];
+            }
+        }
+        throw new IllegalArgumentException("Не удалось определить идентификатор Google Sheets из ссылки");
+    }
+
+    private static String extractGid(URI uri) {
+        Map<String, String> queryParams = splitParams(uri.getQuery());
+        if (queryParams.containsKey("gid")) {
+            return queryParams.get("gid");
+        }
+        return splitParams(uri.getFragment()).getOrDefault("gid", "");
+    }
+
+    private static Map<String, String> splitParams(String rawParams) {
+        Map<String, String> params = new LinkedHashMap<>();
+        if (!StringUtils.hasText(rawParams)) {
+            return params;
+        }
+        for (String param : rawParams.split("&")) {
+            String[] pair = param.split("=", 2);
+            if (pair.length == 2 && StringUtils.hasText(pair[0])) {
+                params.put(pair[0], pair[1]);
+            }
+        }
+        return params;
+    }
+
+    private static String requireValue(String value, String label) {
+        String trimmed = value == null ? null : value.trim();
+        if (trimmed == null || trimmed.isEmpty()) {
+            throw new IllegalArgumentException("Поле \"" + label + "\" обязательно");
+        }
+        return trimmed;
+    }
+
+    private record ParsedStudentRow(
+            int rowNumber,
+            String firstNameFull,
+            String lastName,
+            String login,
+            String email,
+            String group
+    ) {
+    }
+
+    private static class HeadersValidationException extends RuntimeException {
+        HeadersValidationException(String message) {
+            super(message);
+        }
+    }
+
+    private static class EmptyFileException extends RuntimeException {
+    }
+
+    private static final Map<String, String> HEADER_FIELD_MAP = Map.of(
+            "имя", "firstName",
+            "фамилия", "lastName",
+            "логин", "login",
+            "адресэлектроннойпочты", "email",
+            "email", "email",
+            "почта", "email",
+            "группы", "group",
+            "группа", "group"
+    );
 
     private Map<Integer, String> buildHeaderMap(Row headerRow) {
         Map<Integer, String> result = new HashMap<>();
@@ -292,37 +582,13 @@ public class StudentService {
 
         for (Cell cell : headerRow) {
             String normalized = normalizeHeader(cellToString(cell));
-
-            switch (normalized) {
-                case "имя" -> result.put(cell.getColumnIndex(), "firstName");
-                case "фамилия" -> result.put(cell.getColumnIndex(), "lastName");
-                case "логин" -> result.put(cell.getColumnIndex(), "login");
-                case "адресэлектроннойпочты", "email", "почта" -> result.put(cell.getColumnIndex(), "email");
-                case "группы", "группа" -> result.put(cell.getColumnIndex(), "group");
+            String field = HEADER_FIELD_MAP.get(normalized);
+            if (field != null) {
+                result.put(cell.getColumnIndex(), field);
             }
         }
 
         return result;
-    }
-
-    private void validateRequiredHeaders(
-            Map<Integer, String> headerMap,
-            StudentImportResponse result
-    ) {
-        Set<String> fields = new HashSet<>(headerMap.values());
-
-        Map<String, String> required = Map.of(
-                "firstName", "Имя",
-                "lastName", "Фамилия",
-                "login", "Логин",
-                "email", "Адрес электронной почты"
-        );
-
-        for (Map.Entry<String, String> entry : required.entrySet()) {
-            if (!fields.contains(entry.getKey())) {
-                result.addError(1, "headers", "Отсутствует обязательная колонка: " + entry.getValue());
-            }
-        }
     }
 
     private Map<String, String> readRow(Row row, Map<Integer, String> headerMap) {
@@ -334,16 +600,6 @@ public class StudentService {
         }
 
         return result;
-    }
-
-    private String required(Map<String, String> data, String field, String label) {
-        String value = trimToNull(data.get(field));
-
-        if (value == null) {
-            throw new IllegalArgumentException("Поле \"" + label + "\" обязательно");
-        }
-
-        return value;
     }
 
     private boolean isEmptyRow(Row row) {

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/StudentService.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/StudentService.java
@@ -16,14 +16,18 @@ import vsu.cs.is.infsysserver.student.adapter.jpa.entity.Student;
 import vsu.cs.is.infsysserver.student.adapter.rest.request.StudentEditRequest;
 import vsu.cs.is.infsysserver.student.adapter.rest.response.StudentImportResponse;
 import vsu.cs.is.infsysserver.student.adapter.rest.response.StudentResponse;
+import vsu.cs.is.infsysserver.student.topic.adapter.jpa.StudentTopicAssignmentRepository;
+import vsu.cs.is.infsysserver.student.topic.adapter.jpa.entity.StudentTopicAssignment;
 import vsu.cs.is.infsysserver.user.adapter.jpa.UserRepository;
 import vsu.cs.is.infsysserver.user.adapter.jpa.entity.User;
 
 import java.io.InputStream;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -36,11 +40,41 @@ public class StudentService {
     private final UserRepository userRepository;
     private final DepartmentRepository departmentRepository;
     private final PasswordEncoder passwordEncoder;
+    private final StudentTopicAssignmentRepository studentTopicAssignmentRepository;
 
     public List<StudentResponse> getAllStudents() {
-        return studentRepository.findAll(Sort.by(Sort.Order.asc("isDisabled"), Sort.Order.asc("id"))).stream()
-                .map(StudentResponse::new)
+        List<Student> students = studentRepository.findAll(
+                Sort.by(Sort.Order.asc("isDisabled"), Sort.Order.asc("id"))
+        );
+        if (students.isEmpty()) {
+            return List.of();
+        }
+
+        Set<Long> ids = students.stream()
+                .map(Student::getId)
+                .collect(Collectors.toSet());
+
+        Map<Long, StudentTopicAssignment> assignments = studentTopicAssignmentRepository
+                .findAllByStudent_IdIn(ids)
+                .stream()
+                .collect(Collectors.toMap(
+                        a -> a.getStudent().getId(),
+                        Function.identity()
+                ));
+
+        return students.stream()
+                .map(s -> StudentResponse.fromStudentAndTopics(
+                        s, Optional.ofNullable(assignments.get(s.getId()))
+                ))
                 .toList();
+    }
+
+    public Optional<StudentResponse> getStudentById(Long id) {
+        return studentRepository.findById(id)
+                .map(student -> StudentResponse.fromStudentAndTopics(
+                        student,
+                        studentTopicAssignmentRepository.findByStudent_Id(student.getId())
+                ));
     }
 
     public StudentResponse editStudent(Long id, StudentEditRequest edit) {
@@ -85,7 +119,10 @@ public class StudentService {
         student.setUser(user);
         studentRepository.save(student);
 
-        return new StudentResponse(student);
+        return StudentResponse.fromStudentAndTopics(
+                student,
+                studentTopicAssignmentRepository.findByStudent_Id(student.getId())
+        );
     }
 
     public void disableStudent(Long id) {
@@ -115,7 +152,10 @@ public class StudentService {
 
         Student student = studentRepository.findByUser_Id(user.getId());
 
-        return new StudentResponse(student);
+        return StudentResponse.fromStudentAndTopics(
+                student,
+                studentTopicAssignmentRepository.findByStudent_Id(student.getId())
+        );
     }
 
     public StudentImportResponse importStudents(MultipartFile file) {

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/StudentController.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/StudentController.java
@@ -19,13 +19,10 @@ import org.springframework.web.multipart.MultipartFile;
 import vsu.cs.is.infsysserver.security.entity.dto.response.StudentAuthenticationResponse;
 import vsu.cs.is.infsysserver.security.service.AuthenticationService;
 import vsu.cs.is.infsysserver.student.adapter.StudentService;
-import vsu.cs.is.infsysserver.student.adapter.jpa.StudentRepository;
-import vsu.cs.is.infsysserver.student.adapter.jpa.entity.Student;
 import vsu.cs.is.infsysserver.student.adapter.rest.request.StudentEditRequest;
 import vsu.cs.is.infsysserver.student.adapter.rest.request.StudentRequest;
 import vsu.cs.is.infsysserver.student.adapter.rest.response.StudentImportResponse;
 import vsu.cs.is.infsysserver.student.adapter.rest.response.StudentResponse;
-import java.util.Optional;
 
 @RequestMapping("/api")
 @CrossOrigin
@@ -33,7 +30,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class StudentController {
 
-    private final StudentRepository studentRepository;
     private final AuthenticationService authenticationService;
     private final StudentService studentService;
 
@@ -72,10 +68,8 @@ public class StudentController {
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/student/{id}")
     public ResponseEntity<StudentResponse> getById(@PathVariable Long id) {
-        Optional<Student> optionalStudent = studentRepository.findById(id);
-
-        return optionalStudent.map(student ->
-                        ResponseEntity.ok(new StudentResponse(student)))
+        return studentService.getStudentById(id)
+                .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(null));
     }
 

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/StudentController.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/StudentController.java
@@ -20,6 +20,7 @@ import vsu.cs.is.infsysserver.security.entity.dto.response.StudentAuthentication
 import vsu.cs.is.infsysserver.security.service.AuthenticationService;
 import vsu.cs.is.infsysserver.student.adapter.StudentService;
 import vsu.cs.is.infsysserver.student.adapter.rest.request.StudentEditRequest;
+import vsu.cs.is.infsysserver.student.adapter.rest.request.StudentImportUrlRequest;
 import vsu.cs.is.infsysserver.student.adapter.rest.request.StudentRequest;
 import vsu.cs.is.infsysserver.student.adapter.rest.response.StudentImportResponse;
 import vsu.cs.is.infsysserver.student.adapter.rest.response.StudentResponse;
@@ -84,14 +85,23 @@ public class StudentController {
     public ResponseEntity<StudentImportResponse> importStudents(
             @RequestParam("file") MultipartFile file
     ) {
-        StudentImportResponse response = studentService.importStudents(file);
+        return toResponseEntity(studentService.importStudents(file));
+    }
 
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/students/import/google-sheet")
+    public ResponseEntity<StudentImportResponse> importStudentsFromGoogleSheet(
+            @RequestBody StudentImportUrlRequest request
+    ) {
+        return toResponseEntity(studentService.importStudentsFromGoogleSheet(request.url()));
+    }
+
+    private static ResponseEntity<StudentImportResponse> toResponseEntity(StudentImportResponse response) {
         if (response.getCreated() == 0
                 && response.getUpdated() == 0
                 && !response.getErrors().isEmpty()) {
             return ResponseEntity.badRequest().body(response);
         }
-
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/request/StudentImportUrlRequest.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/request/StudentImportUrlRequest.java
@@ -1,0 +1,6 @@
+package vsu.cs.is.infsysserver.student.adapter.rest.request;
+
+public record StudentImportUrlRequest(
+        String url
+) {
+}

--- a/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/response/StudentResponse.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/adapter/rest/response/StudentResponse.java
@@ -5,6 +5,7 @@ import lombok.Data;
 import vsu.cs.is.infsysserver.security.entity.temp.Role;
 import vsu.cs.is.infsysserver.student.adapter.jpa.entity.Department;
 import vsu.cs.is.infsysserver.student.adapter.jpa.entity.Student;
+import vsu.cs.is.infsysserver.student.topic.adapter.jpa.entity.StudentTopicAssignment;
 import vsu.cs.is.infsysserver.user.adapter.jpa.entity.User;
 
 import java.util.Optional;
@@ -45,6 +46,32 @@ public class StudentResponse {
     private String departmentInfo;
 
     private Boolean isActive;
+
+    private String supervisorFullName;
+
+    private Long supervisorEmployeeId;
+
+    private String courseWorkTopic;
+
+    private String thesisTopic;
+
+    public static StudentResponse fromStudentAndTopics(
+            Student student,
+            Optional<StudentTopicAssignment> assignment
+    ) {
+        StudentResponse response = new StudentResponse(student);
+        assignment.ifPresent(a -> {
+            response.setSupervisorFullName(a.getSupervisorFullName());
+            response.setSupervisorEmployeeId(
+                    a.getSupervisorEmployee() != null
+                            ? a.getSupervisorEmployee().getId()
+                            : null
+            );
+            response.setCourseWorkTopic(a.getCourseWorkTopic());
+            response.setThesisTopic(a.getThesisTopic());
+        });
+        return response;
+    }
 
     public StudentResponse(Student student) {
         this.id = student.getId();

--- a/src/main/java/vsu/cs/is/infsysserver/student/topic/adapter/jpa/StudentTopicAssignmentRepository.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/topic/adapter/jpa/StudentTopicAssignmentRepository.java
@@ -3,6 +3,8 @@ package vsu.cs.is.infsysserver.student.topic.adapter.jpa;
 import org.springframework.data.jpa.repository.JpaRepository;
 import vsu.cs.is.infsysserver.student.topic.adapter.jpa.entity.StudentTopicAssignment;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 public interface StudentTopicAssignmentRepository extends JpaRepository<StudentTopicAssignment, Long> {
@@ -12,4 +14,6 @@ public interface StudentTopicAssignmentRepository extends JpaRepository<StudentT
     Optional<StudentTopicAssignment> findByStudent_User_Login(String studentLogin);
 
     Optional<StudentTopicAssignment> findByStudentLogin(String studentLogin);
+
+    List<StudentTopicAssignment> findAllByStudent_IdIn(Collection<Long> studentIds);
 }

--- a/src/main/java/vsu/cs/is/infsysserver/student/topic/adapter/rest/StudentTopicsController.java
+++ b/src/main/java/vsu/cs/is/infsysserver/student/topic/adapter/rest/StudentTopicsController.java
@@ -38,6 +38,13 @@ public class StudentTopicsController {
         return studentTopicsService.importGoogleSheet(request.url());
     }
 
+    /**
+     * @deprecated Используйте поля supervisorFullName, supervisorEmployeeId,
+     * courseWorkTopic, thesisTopic в основном StudentResponse
+     * (GET /api/students, /api/student/{id}, /api/student/account).
+     * Endpoint оставлен для обратной совместимости и будет удалён в следующих итерациях.
+     */
+    @Deprecated
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/students/topics/{studentLogin}")
     public ResponseEntity<StudentTopicsResponse> getTopicsByStudentLogin(@PathVariable String studentLogin) {
@@ -46,6 +53,13 @@ public class StudentTopicsController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    /**
+     * @deprecated Используйте поля supervisorFullName, supervisorEmployeeId,
+     * courseWorkTopic, thesisTopic в основном StudentResponse
+     * (GET /api/student/{id}).
+     * Endpoint оставлен для обратной совместимости и будет удалён в следующих итерациях.
+     */
+    @Deprecated
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/students/{studentId}/topics")
     public ResponseEntity<StudentTopicsResponse> getTopicsByStudentId(@PathVariable Long studentId) {
@@ -54,6 +68,13 @@ public class StudentTopicsController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    /**
+     * @deprecated Используйте поля supervisorFullName, supervisorEmployeeId,
+     * courseWorkTopic, thesisTopic в основном StudentResponse
+     * (GET /api/student/account).
+     * Endpoint оставлен для обратной совместимости и будет удалён в следующих итерациях.
+     */
+    @Deprecated
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/student/account/topics")
     public ResponseEntity<StudentTopicsResponse> getCurrentStudentTopics() {

--- a/src/test/java/vsu/cs/is/infsysserver/security/config/SecurityConfigTest.java
+++ b/src/test/java/vsu/cs/is/infsysserver/security/config/SecurityConfigTest.java
@@ -109,6 +109,7 @@ class SecurityConfigTest {
         given(uploadService.uploadFile(any())).willReturn("/api/files/test.png");
         given(studentService.getCurrentStudent()).willReturn(studentResponse());
         given(studentService.importStudents(any())).willReturn(new StudentImportResponse());
+        given(studentService.getStudentById(anyLong())).willReturn(Optional.of(studentResponse()));
         given(studentRepository.findById(anyLong())).willReturn(Optional.of(studentEntity()));
     }
 

--- a/src/test/java/vsu/cs/is/infsysserver/student/adapter/StudentServiceImportTest.java
+++ b/src/test/java/vsu/cs/is/infsysserver/student/adapter/StudentServiceImportTest.java
@@ -167,4 +167,45 @@ class StudentServiceImportTest {
         verify(userRepository).save(userCaptor.capture());
         assertEquals("", userCaptor.getValue().getPassword());
     }
+
+    @Test
+    @DisplayName("CSV файл — парсится так же, как xlsx")
+    void importStudents_CsvFile_ParsesSameWayAsXlsx() {
+        String csv = "Имя,Фамилия,Логин,Адрес электронной почты,Группы\n"
+                + "Гагик Арманович,Асатрян,16250362,gagik@gmail.com,2025_1к_ФКН_09.04.02_Оч_0_25\n";
+        var file = new MockMultipartFile(
+                "file", "students.csv", "text/csv", csv.getBytes()
+        );
+        when(userRepository.findByLogin("16250362")).thenReturn(java.util.Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(studentRepository.findByUser_Id(any())).thenReturn(null);
+
+        StudentImportResponse result = studentService.importStudents(file);
+
+        assertEquals(1, result.getCreated());
+        assertEquals(0, result.getUpdated());
+        assertEquals(0, result.getSkipped());
+
+        ArgumentCaptor<Student> studCaptor = ArgumentCaptor.forClass(Student.class);
+        verify(studentRepository).save(studCaptor.capture());
+        Student stud = studCaptor.getValue();
+        assertEquals("Арманович", stud.getPatronymic());
+        assertEquals(2025, stud.getStartYear());
+        assertEquals(1, stud.getCourse());
+    }
+
+    @Test
+    @DisplayName("Не поддерживаемое расширение — ошибка с указанием на .xlsx и .csv")
+    void importStudents_UnsupportedExtension_AddsError() {
+        var file = new MockMultipartFile(
+                "file", "list.txt", "text/plain", "garbage".getBytes()
+        );
+
+        StudentImportResponse result = studentService.importStudents(file);
+
+        assertEquals(0, result.getCreated());
+        assertEquals(0, result.getUpdated());
+        assertEquals(1, result.getErrors().size());
+        verify(userRepository, never()).save(any());
+    }
 }

--- a/src/test/java/vsu/cs/is/infsysserver/student/adapter/StudentServiceTopicsEnrichmentTest.java
+++ b/src/test/java/vsu/cs/is/infsysserver/student/adapter/StudentServiceTopicsEnrichmentTest.java
@@ -1,0 +1,216 @@
+package vsu.cs.is.infsysserver.student.adapter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import vsu.cs.is.infsysserver.employee.adapter.jpa.entity.Employee;
+import vsu.cs.is.infsysserver.student.adapter.jpa.DepartmentRepository;
+import vsu.cs.is.infsysserver.student.adapter.jpa.StudentRepository;
+import vsu.cs.is.infsysserver.student.adapter.jpa.entity.Student;
+import vsu.cs.is.infsysserver.student.adapter.rest.request.StudentEditRequest;
+import vsu.cs.is.infsysserver.student.adapter.rest.response.StudentResponse;
+import vsu.cs.is.infsysserver.student.topic.adapter.jpa.StudentTopicAssignmentRepository;
+import vsu.cs.is.infsysserver.student.topic.adapter.jpa.entity.StudentTopicAssignment;
+import vsu.cs.is.infsysserver.user.adapter.jpa.UserRepository;
+import vsu.cs.is.infsysserver.user.adapter.jpa.entity.User;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Обогащение StudentResponse темами и руководителем")
+class StudentServiceTopicsEnrichmentTest {
+
+    @Mock private StudentRepository studentRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private DepartmentRepository departmentRepository;
+    @Mock private PasswordEncoder passwordEncoder;
+    @Mock private StudentTopicAssignmentRepository studentTopicAssignmentRepository;
+
+    @InjectMocks private StudentService studentService;
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("getAllStudents — студент с assignment'ом получает все 4 новых поля")
+    void getAllStudents_WithAssignment_FillsAllNewFields() {
+        Student student = buildStudent(1L, "ivanov_i_i");
+        Employee supervisor = new Employee();
+        supervisor.setId(7L);
+        StudentTopicAssignment assignment = StudentTopicAssignment.builder()
+                .student(student)
+                .supervisorFullName("Петров Пётр Петрович")
+                .supervisorEmployee(supervisor)
+                .courseWorkTopic("Курсовая ABC")
+                .thesisTopic("ВКР XYZ")
+                .build();
+
+        when(studentRepository.findAll(any(Sort.class))).thenReturn(List.of(student));
+        when(studentTopicAssignmentRepository.findAllByStudent_IdIn(Set.of(1L)))
+                .thenReturn(List.of(assignment));
+
+        List<StudentResponse> result = studentService.getAllStudents();
+
+        assertEquals(1, result.size());
+        StudentResponse response = result.get(0);
+        assertEquals("Петров Пётр Петрович", response.getSupervisorFullName());
+        assertEquals(7L, response.getSupervisorEmployeeId());
+        assertEquals("Курсовая ABC", response.getCourseWorkTopic());
+        assertEquals("ВКР XYZ", response.getThesisTopic());
+    }
+
+    @Test
+    @DisplayName("getAllStudents — студент без assignment'а: все 4 новых поля null")
+    void getAllStudents_WithoutAssignment_NewFieldsNull() {
+        Student student = buildStudent(2L, "petrov_p_p");
+
+        when(studentRepository.findAll(any(Sort.class))).thenReturn(List.of(student));
+        when(studentTopicAssignmentRepository.findAllByStudent_IdIn(Set.of(2L)))
+                .thenReturn(List.of());
+
+        List<StudentResponse> result = studentService.getAllStudents();
+
+        assertEquals(1, result.size());
+        assertNull(result.get(0).getSupervisorFullName());
+        assertNull(result.get(0).getSupervisorEmployeeId());
+        assertNull(result.get(0).getCourseWorkTopic());
+        assertNull(result.get(0).getThesisTopic());
+    }
+
+    @Test
+    @DisplayName("getAllStudents — пустой список: возвращается пустой результат без падения")
+    void getAllStudents_EmptyList_ReturnsEmpty() {
+        when(studentRepository.findAll(any(Sort.class))).thenReturn(List.of());
+
+        List<StudentResponse> result = studentService.getAllStudents();
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    @DisplayName("getCurrentStudent — assignment подтянут и поля заполнены")
+    void getCurrentStudent_WithAssignment_FillsFields() {
+        Student student = buildStudent(1L, "ivanov_i_i");
+        StudentTopicAssignment assignment = StudentTopicAssignment.builder()
+                .student(student)
+                .courseWorkTopic("Курсовая 4 курс")
+                .build();
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("ivanov_i_i", null)
+        );
+
+        when(userRepository.findByLogin("ivanov_i_i")).thenReturn(Optional.of(student.getUser()));
+        when(studentRepository.findByUser_Id(1L)).thenReturn(student);
+        when(studentTopicAssignmentRepository.findByStudent_Id(1L))
+                .thenReturn(Optional.of(assignment));
+
+        StudentResponse response = studentService.getCurrentStudent();
+
+        assertEquals("Курсовая 4 курс", response.getCourseWorkTopic());
+    }
+
+    @Test
+    @DisplayName("getCurrentStudent — без assignment'а: новые поля null")
+    void getCurrentStudent_WithoutAssignment_NewFieldsNull() {
+        Student student = buildStudent(2L, "petrov_p_p");
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken("petrov_p_p", null)
+        );
+
+        when(userRepository.findByLogin("petrov_p_p")).thenReturn(Optional.of(student.getUser()));
+        when(studentRepository.findByUser_Id(2L)).thenReturn(student);
+        when(studentTopicAssignmentRepository.findByStudent_Id(2L))
+                .thenReturn(Optional.empty());
+
+        StudentResponse response = studentService.getCurrentStudent();
+
+        assertNull(response.getCourseWorkTopic());
+        assertNull(response.getThesisTopic());
+        assertNull(response.getSupervisorFullName());
+    }
+
+    @Test
+    @DisplayName("getStudentById — найден с assignment'ом: возвращает обогащённый Optional")
+    void getStudentById_WithAssignment_ReturnsEnriched() {
+        Student student = buildStudent(3L, "ivanov_i_i");
+        StudentTopicAssignment assignment = StudentTopicAssignment.builder()
+                .student(student)
+                .thesisTopic("ВКР тема")
+                .build();
+
+        when(studentRepository.findById(3L)).thenReturn(Optional.of(student));
+        when(studentTopicAssignmentRepository.findByStudent_Id(3L))
+                .thenReturn(Optional.of(assignment));
+
+        Optional<StudentResponse> result = studentService.getStudentById(3L);
+
+        assertTrue(result.isPresent());
+        assertEquals("ВКР тема", result.get().getThesisTopic());
+    }
+
+    @Test
+    @DisplayName("getStudentById — не найден: возвращает Optional.empty()")
+    void getStudentById_NotFound_ReturnsEmpty() {
+        when(studentRepository.findById(99L)).thenReturn(Optional.empty());
+
+        Optional<StudentResponse> result = studentService.getStudentById(99L);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("editStudent — после save возвращает обогащённый response")
+    void editStudent_ReturnsEnrichedResponse() {
+        Student student = buildStudent(4L, "sidorov_s_s");
+        StudentTopicAssignment assignment = StudentTopicAssignment.builder()
+                .student(student)
+                .courseWorkTopic("Курсовая после edit")
+                .build();
+
+        when(studentRepository.findById(4L)).thenReturn(Optional.of(student));
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(studentRepository.save(any(Student.class))).thenAnswer(inv -> inv.getArgument(0));
+        when(studentTopicAssignmentRepository.findByStudent_Id(4L))
+                .thenReturn(Optional.of(assignment));
+
+        StudentEditRequest edit = new StudentEditRequest();
+        edit.setFirstName("Сидор");
+
+        StudentResponse response = studentService.editStudent(4L, edit);
+
+        assertEquals("Курсовая после edit", response.getCourseWorkTopic());
+    }
+
+    private static Student buildStudent(long id, String login) {
+        User user = User.builder()
+                .id(id)
+                .login(login)
+                .firstName("Имя")
+                .lastName("Фамилия")
+                .build();
+        return Student.builder()
+                .id(id)
+                .user(user)
+                .build();
+    }
+}


### PR DESCRIPTION
### Темы и научный руководитель в `StudentResponse`                                                                                                                                                    
  Поля `supervisorFullName`, `supervisorEmployeeId`, `courseWorkTopic`, `thesisTopic` теперь возвращаются всеми «студенческими» эндпоинтами:
  - `GET /api/students` — bulk через `findAllByStudent_IdIn` (один SQL вместо N+1).                                                                                                                      
  - `GET /api/student/{id}` — single-lookup.                                                                                                                                                             
  - `GET /api/student/account` — single-lookup.                                                                                                                                                          
  - `POST /api/students` (registerStudent) — null-поля для нового студента.                                                                                                                              
  - `PUT /api/students/{id}` (editStudent) — актуальные темы после правки.                                                                                                                               
                                                                                                                                                                                                         
  Добавлена статическая фабрика `StudentResponse.fromStudentAndTopics(Student, Optional<StudentTopicAssignment>)`.                                                                                       
                                                                                                                                                                                                         
  ### Архитектурная чистка                                                                                                                                                                               
  - Логика `getById` вынесена из `StudentController` в `StudentService.getStudentById(Long): Optional<StudentResponse>`.
  - `Collectors.toMap` без merge-function — fail-fast при невозможном дублировании.                                                                                                                      
                                                                                                                                                                                                         
  ### Депрекация дублирующих эндпоинтов                                                                                                                                                                  
  `/student/account/topics`, `/students/{id}/topics`, `/students/topics/{login}` помечены `@Deprecated` — тот же контент теперь приходит в основном `StudentResponse`.                                   
                                                                                                                                                                                                         
  ### Унификация импорта студентов                       
  - `POST /api/students/import` (multipart) теперь принимает `.xlsx` И `.csv`.                                                                                                                           
  - Новый `POST /api/students/import/google-sheet` (JSON `{url}`) — импорт по ссылке на публичную Google Sheets через CSV-export.                                                                        
  - Парсинг разделён на `parseXlsx` / `parseCsv` + общий `importRows(List<ParsedStudentRow>)`. Заголовки нормализуются через единую `HEADER_FIELD_MAP`.                                                  
                                                                                                                                                                                                         
  ### Тесты                                                                                                                                                                                              
  - `StudentServiceTopicsEnrichmentTest` (новый, 8 тестов): обогащение `getAllStudents`, `getCurrentStudent`, `getStudentById`, `editStudent`.                                                           
  - `StudentServiceImportTest` (расширен): CSV-парсинг и неподдерживаемое расширение. 